### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest-version": 1,
+  "baseline-sha": "926c453048fd37809fc5de01a4227750356a4ded",
+  "release-targets": [
+    {
+      "path": ".",
+      "version": "1.11.0",
+      "tag": "v1.11.0"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.11.0](https://github.com/jolars/sortedl1/compare/v1.10.0...v1.11.0) (2026-06-02)
+
+### Features
+- add `score` and `set_score_request` methods to `Slope` ([`5f53a08`](https://github.com/jolars/sortedl1/commit/5f53a0851b6da4b56d9251cfb90fdfbff2755674)), closes [#67](https://github.com/jolars/sortedl1/issues/67)
+
 ## [1.10.0](https://github.com/jolars/sortedl1/compare/v1.9.0...v1.10.0) (2026-03-27)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sortedl1"
-version = "1.10.0"
+version = "1.11.0"
 description = "Sorted L-One Penalized Estimation"
 readme = "README.md"
 maintainers = [{ name = "Johan Larsson", email = "johanlarsson@outlook.com" }]

--- a/sortedl1/__init__.py
+++ b/sortedl1/__init__.py
@@ -5,4 +5,4 @@ from .results import CvResults, PathResults
 
 __all__ = ["CvResults", "PathResults", "Slope"]
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"


### PR DESCRIPTION
## [1.11.0](https://github.com/jolars/sortedl1/compare/v1.10.0...v1.11.0) (2026-06-02)

### Features
- add `score` and `set_score_request` methods to `Slope` ([`5f53a08`](https://github.com/jolars/sortedl1/commit/5f53a0851b6da4b56d9251cfb90fdfbff2755674)), closes [#67](https://github.com/jolars/sortedl1/issues/67)

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).