### PR TITLE
chore(release): v1.11.1

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "926c453048fd37809fc5de01a4227750356a4ded",
+  "baseline-sha": "38be3f61f5809d25e807d6815c9dd149a9d8ad4a",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.11.0",
-      "tag": "v1.11.0"
+      "version": "1.11.1",
+      "tag": "v1.11.1"
+    }
+  ],
+  "pending-release-targets": [
+    {
+      "path": ".",
+      "version": "1.11.1",
+      "tag": "v1.11.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.11.1](https://github.com/jolars/sortedl1/compare/v1.11.0...v1.11.1) (2026-08-27)
+
+### Bug Fixes
+- update to libslope 6.5.2 ([`38be3f6`](https://github.com/jolars/sortedl1/commit/38be3f61f5809d25e807d6815c9dd149a9d8ad4a))
+
 ## [1.11.0](https://github.com/jolars/sortedl1/compare/v1.10.0...v1.11.0) (2026-06-02)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sortedl1"
-version = "1.11.0"
+version = "1.11.1"
 description = "Sorted L-One Penalized Estimation"
 readme = "README.md"
 maintainers = [{ name = "Johan Larsson", email = "johanlarsson@outlook.com" }]

--- a/sortedl1/__init__.py
+++ b/sortedl1/__init__.py
@@ -5,4 +5,4 @@ from .results import CvResults, PathResults
 
 __all__ = ["CvResults", "PathResults", "Slope"]
 
-__version__ = "1.11.0"
+__version__ = "1.11.1"


### PR DESCRIPTION
## [1.11.1](https://github.com/jolars/sortedl1/compare/v1.11.0...v1.11.1) (2026-08-27)

### Bug Fixes
- update to libslope 6.5.2 ([`38be3f6`](https://github.com/jolars/sortedl1/commit/38be3f61f5809d25e807d6815c9dd149a9d8ad4a))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).